### PR TITLE
Rename package to `embed-typescript`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Embed-TypeScript-Compiler
+# Embed-TypeScript
 
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/embed-typescript-compiler/blob/master/LICENSE)
-[![NPM Version](https://img.shields.io/npm/v/embed-typescript-compiler.svg)](https://www.npmjs.com/package/embed-typescript-compiler)
-[![NPM Downloads](https://img.shields.io/npm/dm/embed-typescript-compiler.svg)](https://www.npmjs.com/package/embed-typescript-compiler)
-[![Build Status](https://github.com/samchon/embed-typescript-compiler/workflows/build/badge.svg)](https://github.com/samchon/embed-typescript-compiler/actions?query=workflow%3Abuild)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/embed-typescript/blob/master/LICENSE)
+[![NPM Version](https://img.shields.io/npm/v/embed-typescript.svg)](https://www.npmjs.com/package/embed-typescript)
+[![NPM Downloads](https://img.shields.io/npm/dm/embed-typescript.svg)](https://www.npmjs.com/package/embed-typescript)
+[![Build Status](https://github.com/samchon/embed-typescript/workflows/build/badge.svg)](https://github.com/samchon/embed-typescript/actions?query=workflow%3Abuild)
 [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
 A powerful library that enables embedding the TypeScript compiler directly into your applications, supporting both Node.js and browser environments.
 
-`embed-typescript-compiler` provides a streamlined API to compile TypeScript code on-the-fly without requiring external build tools or processes. This makes it ideal for applications that need to dynamically compile TypeScript code, such as playgrounds, code editors, or automated code generation tools.
+`embed-typescript` provides a streamlined API to compile TypeScript code on-the-fly without requiring external build tools or processes. This makes it ideal for applications that need to dynamically compile TypeScript code, such as playgrounds, code editors, or automated code generation tools.
 
 ## Features
 
@@ -22,7 +22,7 @@ A powerful library that enables embedding the TypeScript compiler directly into 
 
 ```bash
 npm install typescript
-npm install embed-typescript-compiler
+npm install embed-typescript
 ```
 
 Note: TypeScript is a peer dependency that must be installed separately.
@@ -37,7 +37,7 @@ The following example demonstrates how to create an embedded TypeScript compiler
 import {
   EmbedTypeScript,
   IEmbedTypeScriptResult,
-} from "embed-typescript-compiler";
+} from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
 
@@ -103,7 +103,7 @@ npm install @types/node @samchon/openapi typia
 
 # 2. Use the CLI tool to extract type definitions into a JSON file
 cd ..
-npx embed-typescript-compiler external \
+npx embed-typescript external \
   --input ./compiler-dependencies \
   --output ./src/external.json
 ```
@@ -151,7 +151,7 @@ The `compile` method returns an `IEmbedTypeScriptResult` which can be one of thr
 
 ![Typia Playground](https://github.com/user-attachments/assets/2e60f5e8-a419-4f35-b9e4-71ae265d5785)
 
-`embed-typescript-compiler` is used in several production applications:
+`embed-typescript` is used in several production applications:
 
 - [`typia` playground](https://typia.io/playground) - TypeScript type to runtime function
 - [`AutoBE`](https://github.com/wrtnlabs/autobe) - AI viral coding agent of backend server with compiler feedback

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "embed-typescript-compiler",
+  "name": "embed-typescript",
   "version": "1.0.0",
   "description": "Embed TypeScript Compiler in your NodeJS/Browser Application",
   "main": "src/index.ts",
@@ -14,14 +14,15 @@
     "nodejs",
     "browser"
   ],
+  "license": "MIT",
+  "author": "Jeongho Nam",
   "repository": {
     "type": "git",
-    "url": "https://github.com/samchon/embed-typescript-compiler"
+    "url": "https://github.com/samchon/embed-typescript"
   },
-  "author": "Jeongho Nam",
-  "license": "MIT",
+  "homepage": "https://github.com/samchon/embed-typescript",
   "bugs": {
-    "url": "https://github.com/samchon/embed-typescript-compiler/issues"
+    "url": "https://github.com/samchon/embed-typescript/issues"
   },
   "peerDependencies": {
     "typescript": ">=5.0.0 <6.0.0"
@@ -38,7 +39,7 @@
   },
   "publishConfig": {
     "bin": {
-      "embed-typescript-compiler": "lib/cli/index.js"
+      "embed-typescript": "lib/cli/index.js"
     },
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
-      embed-typescript-compiler:
+      embed-typescript:
         specifier: workspace:^
         version: link:..
       tstl:

--- a/src/cli/EmbedTypeScriptCliUtil.ts
+++ b/src/cli/EmbedTypeScriptCliUtil.ts
@@ -11,17 +11,17 @@ export namespace EmbedTypeScriptCliUtil {
   }
 }
 
-const USAGE = `npx embed-typescript-compiler [command] [options]
+const USAGE = `npx embed-typescript [command] [options]
 
 Commands:
   
-  1. embed-typescript-compiler help
-  2. embed-typescript-compiler external --input <directory> --output <json>
+  1. embed-typescript help
+  2. embed-typescript external --input <directory> --output <json>
      - input: directory placed in external dependencies
        - where "node_modules" and "package-lock.json" are
        - must be installed with npm, not pnpm or yarn
      - output: json file to be generated
-      - example: embed-typescript-compiler external \\
+      - example: embed-typescript external \\
                    --input assets/dependencies \\ 
                    --output src/external.json 
 `;

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@embed-typescript-compiler/test",
+  "name": "@embed-typescript/test",
   "version": "0.0.0",
-  "description": "Test functions for embed-typescript-compiler",
+  "description": "Test functions for embed-typescript",
   "scripts": {
     "prepare": "ts-patch install",
     "start": "ts-node src/index.ts"
@@ -16,7 +16,7 @@
   "dependencies": {
     "@nestia/e2e": "^6.0.3",
     "chalk": "4.1.2",
-    "embed-typescript-compiler": "workspace:^",
+    "embed-typescript": "workspace:^",
     "tstl": "^3.0.0",
     "typia": "^9.3.0"
   }

--- a/test/src/features/test_compile_failure.ts
+++ b/test/src/features/test_compile_failure.ts
@@ -2,7 +2,7 @@ import { TestValidator } from "@nestia/e2e";
 import {
   EmbedTypeScript,
   IEmbedTypeScriptResult,
-} from "embed-typescript-compiler";
+} from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
 

--- a/test/src/features/test_compile_javascript.ts
+++ b/test/src/features/test_compile_javascript.ts
@@ -2,7 +2,7 @@ import cp from "child_process";
 import {
   EmbedTypeScript,
   IEmbedTypeScriptResult,
-} from "embed-typescript-compiler";
+} from "embed-typescript";
 import fs from "fs";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";

--- a/test/src/features/test_compile_success.ts
+++ b/test/src/features/test_compile_success.ts
@@ -2,7 +2,7 @@ import { TestValidator } from "@nestia/e2e";
 import {
   EmbedTypeScript,
   IEmbedTypeScriptResult,
-} from "embed-typescript-compiler";
+} from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
 

--- a/test/src/features/test_compile_transform_failure.ts
+++ b/test/src/features/test_compile_transform_failure.ts
@@ -2,7 +2,7 @@ import { TestValidator } from "@nestia/e2e";
 import {
   EmbedTypeScript,
   IEmbedTypeScriptResult,
-} from "embed-typescript-compiler";
+} from "embed-typescript";
 import ts from "typescript";
 import typiaTransform from "typia/lib/transform";
 


### PR DESCRIPTION
This pull request includes a rename of the package from `embed-typescript-compiler` to `embed-typescript` across multiple files and contexts, along with updates to associated metadata and usage examples. The changes ensure consistency in naming and functionality throughout the project.

### Package Renaming:

* Updated the package name in `README.md` to reflect the new name `embed-typescript`, including changes to usage examples, import statements, and references to the package. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R40) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R106) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R154)
* Changed the `name` field in `package.json` from `embed-typescript-compiler` to `embed-typescript`, along with updates to the repository URL, homepage, and bug tracking URLs. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17-R25)
* Updated the CLI command references in `src/cli/EmbedTypeScriptCliUtil.ts` to use `embed-typescript` instead of `embed-typescript-compiler`.

### Dependency and Test Updates:

* Updated references to the renamed package in `pnpm-lock.yaml` and `test/package.json`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL39-R39) [[2]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL2-R4) [[3]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL19-R19)
* Modified import statements in test files to use `embed-typescript` instead of `embed-typescript-compiler`. [[1]](diffhunk://#diff-4fd562f67d5ce701be3b4f5b22448eeec67e580b6973449abf3c3710edd7c62fL5-R5) [[2]](diffhunk://#diff-7f2a8036b454073ec5d9aa309030b34b83133cd45f29f72cce2947a7d896746fL5-R5) [[3]](diffhunk://#diff-9c5d3c76c76a5c4c049be67584ce1bb38aabf63fc20d9412e3610f377a0e25a8L5-R5) [[4]](diffhunk://#diff-8957535ebd2bd30679cd0c62b5988fd2090fe9fe948493847e46e5b00f07f66bL5-R5)

These changes collectively ensure that the package name is consistently updated across the codebase, documentation, and metadata.