### PR TITLE
Special fix for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-typescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Embed TypeScript Compiler in your NodeJS/Browser Application",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
This pull request includes a version update for the `embed-typescript` package and several improvements to file path handling in the `EmbedTypeScriptExternal` CLI module. The most significant changes involve replacing `path.join` with `path.resolve` to ensure absolute paths are consistently used, and normalizing path separators for cross-platform compatibility.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.0.0` to `1.0.1`.

### File path handling improvements:

* [`src/cli/EmbedTypeScriptExternal.ts`](diffhunk://#diff-d69743d9e036d5082978e81b45b2e566771201d9714b550a941235516602c805L23-R28): Replaced `path.join` with `path.resolve` in multiple locations to ensure absolute paths are used when checking for the existence of `node_modules` and `package-lock.json`, reading `package-lock.json`, and resolving paths during dependency collection. [[1]](diffhunk://#diff-d69743d9e036d5082978e81b45b2e566771201d9714b550a941235516602c805L23-R28) [[2]](diffhunk://#diff-d69743d9e036d5082978e81b45b2e566771201d9714b550a941235516602c805L61-R64) [[3]](diffhunk://#diff-d69743d9e036d5082978e81b45b2e566771201d9714b550a941235516602c805L71-R74) [[4]](diffhunk://#diff-d69743d9e036d5082978e81b45b2e566771201d9714b550a941235516602c805L84-R87)
* [`src/cli/EmbedTypeScriptExternal.ts`](diffhunk://#diff-d69743d9e036d5082978e81b45b2e566771201d9714b550a941235516602c805R110-R111): Normalized path separators by replacing `path.sep` with `/` to improve cross-platform compatibility when constructing keys for the `container` object.