### PR TITLE
Add `EmbedTypeScript.fountain()` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-typescript",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Embed TypeScript Compiler in your NodeJS/Browser Application",
   "main": "src/index.ts",
   "scripts": {
@@ -35,7 +35,7 @@
     "@types/node": "^22.15.18",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "publishConfig": {
     "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,17 +44,17 @@ importers:
         version: 3.0.0
       typia:
         specifier: ^9.3.0
-        version: 9.3.0(@samchon/openapi@4.3.0)(typescript@5.8.3)
+        version: 9.3.0(@samchon/openapi@4.3.0)(typescript@5.9.2)
     devDependencies:
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.15.18)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.15.18)(typescript@5.9.2)
       ts-patch:
         specifier: ^3.3.0
         version: 3.3.0
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
 packages:
 
@@ -596,11 +596,6 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -1120,7 +1115,7 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
-  ts-node@10.9.2(@types/node@22.15.18)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@22.15.18)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -1134,7 +1129,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -1153,11 +1148,9 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  typescript@5.8.3: {}
-
   typescript@5.9.2: {}
 
-  typia@9.3.0(@samchon/openapi@4.3.0)(typescript@5.8.3):
+  typia@9.3.0(@samchon/openapi@4.3.0)(typescript@5.9.2):
     dependencies:
       '@samchon/openapi': 4.3.0
       '@standard-schema/spec': 1.0.0
@@ -1166,7 +1159,7 @@ snapshots:
       inquirer: 8.2.6
       package-manager-detector: 0.2.11
       randexp: 0.5.3
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   undici-types@6.21.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
   test:
     dependencies:
@@ -601,6 +601,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typia@9.3.0:
     resolution: {integrity: sha512-srQSYteGIrMiM36y/8MfqrCYA2RWyk4Bb7Xrlk3Ywfpc7AmmzcxwZkPuC4xOkI1IwRfjkhM7k4wviRb6WtW46g==}
     hasBin: true
@@ -1149,6 +1154,8 @@ snapshots:
   type-fest@0.21.3: {}
 
   typescript@5.8.3: {}
+
+  typescript@5.9.2: {}
 
   typia@9.3.0(@samchon/openapi@4.3.0)(typescript@5.8.3):
     dependencies:

--- a/src/IEmbedTypeScriptFountain.ts
+++ b/src/IEmbedTypeScriptFountain.ts
@@ -1,0 +1,62 @@
+import { VariadicSingleton } from "tstl";
+import ts from "typescript";
+
+/**
+ * TypeScript compiler foundation components.
+ *
+ * Represents the core components needed for TypeScript compilation
+ * and transformation operations. This interface bundles together all
+ * the essential TypeScript compiler API objects required to process
+ * TypeScript source code.
+ *
+ * The fountain serves as a central container that provides access to
+ * the TypeScript program instance, diagnostic collection, JavaScript
+ * output storage, and source file cache. It acts as the foundation
+ * upon which both compilation and transformation operations are built.
+ *
+ * @author Jeongho Nam - https://github.com/samchon
+ */
+export interface IEmbedTypeScriptFountain {
+  /**
+   * The TypeScript program instance.
+   *
+   * Core compiler API object that manages the compilation process,
+   * provides type checking capabilities, and emits JavaScript output.
+   * This program instance is configured with the compiler options
+   * and virtual file system provided during fountain creation.
+   */
+  program: ts.Program;
+
+  /**
+   * Collection of compilation diagnostics.
+   *
+   * Accumulates all diagnostics (errors, warnings, suggestions, and messages)
+   * encountered during compilation or transformation. This array is populated
+   * by the TypeScript compiler as it processes source files and can be
+   * examined to determine compilation success or failure.
+   */
+  diagnostics: ts.Diagnostic[];
+
+  /**
+   * JavaScript output storage.
+   *
+   * A record mapping output file names to their generated JavaScript content.
+   * This object is populated during the emit phase of compilation when
+   * TypeScript generates JavaScript from the source TypeScript files.
+   * Keys are file paths and values are the compiled JavaScript code strings.
+   */
+  javascript: Record<string, string>;
+
+  /**
+   * Source file cache.
+   *
+   * A singleton cache that lazily creates and stores TypeScript source file
+   * AST representations. This cache ensures that each source file is parsed
+   * only once, improving performance when the same file is accessed multiple
+   * times during compilation or transformation operations.
+   *
+   * The cache accepts a file path as parameter and returns the corresponding
+   * parsed {@link ts.SourceFile} object.
+   */
+  sourceFiles: VariadicSingleton<ts.SourceFile, [file: string]>;
+}

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.9.2"
   },
   "dependencies": {
     "@nestia/e2e": "^6.0.3",


### PR DESCRIPTION
This pull request introduces a refactor to the TypeScript compilation core in the embed-typescript package, focusing on improving code organization, clarity, and maintainability. The main change is the extraction and formalization of the "fountain" concept—a central object bundling the TypeScript program, diagnostics, JavaScript output, and source file cache—into its own interface. Additionally, utility functions for diagnostics are now encapsulated in a namespace, and the package is upgraded to TypeScript 5.9.2.

**Core refactor and architecture improvements:**

* Introduced the `IEmbedTypeScriptFountain` interface in a new file (`src/IEmbedTypeScriptFountain.ts`) to encapsulate the foundational components needed for TypeScript compilation and transformation, including the program, diagnostics, JS output, and source file cache. (`[src/IEmbedTypeScriptFountain.tsR1-R62](diffhunk://#diff-4d3d23ce41c84b088c1b6817ba11fda3d85ecc0356224a76a5d88cd3aa082eaeR1-R62)`)
* Refactored `EmbedTypeScript` methods to use the new `fountain` approach, replacing the previous `prepare` method and updating all internal usages to work with the fountain structure for improved clarity and maintainability. (`[[1]](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292L60-R85)`, `[[2]](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292L118-R131)`, `[[3]](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292L143-R153)`, `[[4]](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292L165-R184)`)

**Utility function encapsulation:**

* Moved and documented the diagnostic category and message extraction functions into the `EmbedTypeScript` namespace, improving discoverability and type safety. (`[src/EmbedTypeScript.tsL219-L240](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292L219-L240)`)

**Dependency and version updates:**

* Upgraded TypeScript dependency from `~5.8.3` to `~5.9.2` in `package.json` and updated corresponding references in `pnpm-lock.yaml`. Also bumped the package version to `1.3.0`. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`, `[[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L38-R38)`, `[[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL28-R29)`, `[[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR604-R608)`, `[[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1158-R1159)`)