### PR TITLE
Fountain getter from `EmbedTypeScript.compile()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-typescript",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Embed TypeScript Compiler in your NodeJS/Browser Application",
   "main": "src/index.ts",
   "scripts": {

--- a/src/EmbedTypeScript.ts
+++ b/src/EmbedTypeScript.ts
@@ -1,4 +1,4 @@
-import { Singleton, VariadicSingleton } from "tstl";
+import { IPointer, Singleton, VariadicSingleton } from "tstl";
 import ts from "typescript";
 
 import { IEmbedTypeScriptDiagnostic } from "./IEmbedTypeScriptDiagnostic";
@@ -53,12 +53,17 @@ export class EmbedTypeScript {
    * error details.
    *
    * @param files A record mapping file names to their TypeScript source code
+   * @param fountainPointer Optional pointer to receive the fountain value
    * @returns A typed result indicating success, failure with diagnostics,
    *          or exception
    */
-  public compile(files: Record<string, string>): IEmbedTypeScriptResult {
+  public compile(
+    files: Record<string, string>,
+    fountainPointer?: IPointer<IEmbedTypeScriptFountain | null>,
+  ): IEmbedTypeScriptResult {
     try {
       const base: IEmbedTypeScriptFountain = this.fountain(files);
+      if (fountainPointer !== undefined) fountainPointer.value = base;
       base.program.emit(
         undefined,
         undefined,


### PR DESCRIPTION
This pull request introduces a minor version update and an API enhancement to the `embed-typescript` package. The main change is the addition of an optional pointer parameter to the `compile` method, allowing callers to access the internal "fountain" value produced during compilation.

API enhancements:

* Added an optional `fountainPointer` parameter of type `IPointer<IEmbedTypeScriptFountain | null>` to the `compile` method in `EmbedTypeScript`, enabling callers to retrieve the internal fountain value after compilation. (`src/EmbedTypeScript.ts`, [[1]](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292L1-R1) [[2]](diffhunk://#diff-a18e799bc0267a06416b306adf9114b5f56df105c73e1a2821439d842185f292R56-R66)

Dependency and versioning:

* Bumped the package version from 1.3.1 to 1.3.2 in `package.json` to reflect the API change.