### PR TITLE
Fix `EmbedEsLint`'s `IEmbedTypeScriptDiagnostic.file`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@samchon/embed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Embed TypeScript and EsLint Compilers in your NodeJS/Browser Application",
   "scripts": {
     "build": "pnpm --filter=./packages/** -r build",

--- a/packages/embed-eslint/src/EmbedEsLint.ts
+++ b/packages/embed-eslint/src/EmbedEsLint.ts
@@ -44,8 +44,8 @@ export class EmbedEsLint {
    */
   public constructor(private readonly props: IEmbedEsLintProps) {
     this.tsc = new EmbedTypeScript(props);
-    this.linter = new Linter({ configType: "eslintrc" });
 
+    this.linter = new Linter({ configType: "eslintrc" });
     this.linter.defineParser("@typescript-eslint/parser", tsParser);
     Object.entries(tsEslintPlugin.rules || {}).forEach(([ruleName, rule]) => {
       this.linter.defineRule(`@typescript-eslint/${ruleName}`, rule as any);
@@ -121,13 +121,11 @@ export class EmbedEsLint {
         ]),
       ),
     };
-
     const messages: Linter.LintMessage[] = this.linter.verify(
       sourceCode,
       eslintConfig as any,
       { filename: fileName },
     );
-
     return messages.map((msg) => transformMessage(msg, fileName, sourceCode));
   }
 }
@@ -157,21 +155,7 @@ const transformMessage = (
   return {
     category: message.severity === 2 ? "error" : "warning",
     code: message.ruleId || message.messageId || "eslint",
-    file: {
-      fileName,
-      text: sourceCode,
-      getLineAndCharacterOfPosition: (pos: number) => {
-        const lines = sourceCode.split("\n");
-        let currentPos = 0;
-        for (let i = 0; i < lines.length; i++) {
-          if (currentPos + lines[i].length >= pos) {
-            return { line: i, character: pos - currentPos };
-          }
-          currentPos += lines[i].length + 1; // +1 for newline
-        }
-        return { line: 0, character: 0 };
-      },
-    } as any,
+    file: fileName,
     start,
     length: end - start,
     messageText: message.message,

--- a/test/src/features/test_eslint_no_floating_promises.ts
+++ b/test/src/features/test_eslint_no_floating_promises.ts
@@ -2,10 +2,11 @@ import { TestValidator } from "@nestia/e2e";
 import { EmbedEsLint } from "embed-eslint";
 import { IEmbedTypeScriptResult } from "embed-typescript";
 import ts from "typescript";
+import typia from "typia";
 
 import { TestGlobal } from "../TestGlobal";
 
-export const test_fountain_eslint = async () => {
+export const test_eslint_no_floating_promises = async () => {
   const compiler: EmbedEsLint = new EmbedEsLint({
     external: await TestGlobal.getExternal(),
     compilerOptions: {
@@ -34,6 +35,7 @@ export const test_fountain_eslint = async () => {
       fetch("something");
     `,
   });
+  typia.assert(result);
   TestValidator.equals("result")(result.type)("failure");
   TestValidator.predicate("result.diagnostics")(
     () =>


### PR DESCRIPTION
This pull request includes a minor version bump and several improvements to the ESLint embedding functionality and its associated tests. The most significant changes are a simplification of the ESLint diagnostic message structure and updates to the test suite to better reflect the intended checks.

**EmbedEsLint improvements:**

* Simplified the structure of the `file` property in ESLint diagnostic messages from an object with metadata and a position function to just the file name string, making the output easier to consume.

**Test suite updates:**

* Renamed the test file from `test_compiler_eslint.ts` to `test_eslint_no_floating_promises.ts` and updated the exported test function name to better describe its purpose.
* Added a call to `typia.assert(result)` in the ESLint test to ensure the result conforms to the expected type.

**Project metadata:**

* Bumped the package version from `2.0.0` to `2.0.1` in `package.json` to reflect these improvements.