### PR TITLE
Add `IEmbedTypeScriptDiagnostic.{line/character}` properties.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org/
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       
       - name: Install Dependencies
         run: pnpm install

--- a/packages/embed-eslint/src/EmbedEsLint.ts
+++ b/packages/embed-eslint/src/EmbedEsLint.ts
@@ -143,12 +143,12 @@ const transformMessage = (
   fileName: string,
   sourceCode: string,
 ): IEmbedTypeScriptDiagnostic => {
-  const start = getPositionFromLineColumn(
+  const start: number = getPositionFromLineColumn(
     sourceCode,
     message.line,
     message.column,
   );
-  const end =
+  const end: number =
     message.endLine && message.endColumn
       ? getPositionFromLineColumn(
           sourceCode,
@@ -163,6 +163,8 @@ const transformMessage = (
     file: fileName,
     start,
     length: end - start,
+    line: message.line,
+    character: message.column,
     messageText: message.message,
   };
 };

--- a/packages/embed-typescript/src/EmbedTypeScript.ts
+++ b/packages/embed-typescript/src/EmbedTypeScript.ts
@@ -76,14 +76,22 @@ export class EmbedTypeScript {
         return {
           type: "failure",
           javascript: base.javascript,
-          diagnostics: base.diagnostics.map((x) => ({
-            file: x.file?.fileName ?? null,
-            category: EmbedTypeScript.getCategory(x.category),
-            code: x.code,
-            start: x.start,
-            length: x.length,
-            messageText: EmbedTypeScript.getMessageText(x.messageText),
-          })),
+          diagnostics: base.diagnostics.map((x) => {
+            const pos: ts.LineAndCharacter | undefined =
+              x.file !== undefined && x.start !== undefined
+                ? x.file.getLineAndCharacterOfPosition(x.start)
+                : undefined;
+            return {
+              file: x.file?.fileName ?? null,
+              category: EmbedTypeScript.getCategory(x.category),
+              code: x.code,
+              start: x.start,
+              length: x.length,
+              line: pos !== undefined ? pos.line + 1 : undefined,
+              character: pos !== undefined ? pos.character + 1 : undefined,
+              messageText: EmbedTypeScript.getMessageText(x.messageText),
+            };
+          }),
         };
       return {
         type: "success",
@@ -149,14 +157,22 @@ export class EmbedTypeScript {
         ? {
             type: "failure",
             typescript,
-            diagnostics: base.diagnostics.map((x) => ({
-              file: x.file?.fileName ?? null,
-              category: EmbedTypeScript.getCategory(x.category),
-              code: x.code,
-              start: x.start,
-              length: x.length,
-              messageText: EmbedTypeScript.getMessageText(x.messageText),
-            })),
+            diagnostics: base.diagnostics.map((x) => {
+              const pos: ts.LineAndCharacter | undefined =
+                x.file !== undefined && x.start !== undefined
+                  ? x.file.getLineAndCharacterOfPosition(x.start)
+                  : undefined;
+              return {
+                file: x.file?.fileName ?? null,
+                category: EmbedTypeScript.getCategory(x.category),
+                code: x.code,
+                start: x.start,
+                length: x.length,
+                line: pos !== undefined ? pos.line + 1 : undefined,
+                character: pos !== undefined ? pos.character + 1 : undefined,
+                messageText: EmbedTypeScript.getMessageText(x.messageText),
+              };
+            }),
           }
         : {
             type: "success",

--- a/packages/embed-typescript/src/IEmbedTypeScriptDiagnostic.ts
+++ b/packages/embed-typescript/src/IEmbedTypeScriptDiagnostic.ts
@@ -35,6 +35,16 @@ export interface IEmbedTypeScriptDiagnostic {
   length: number | undefined;
 
   /**
+   * 1-based line number where the diagnostic starts, or undefined if not available.
+   */
+  line: number | undefined;
+
+  /**
+   * 1-based character (column) position where the diagnostic starts, or undefined if not available.
+   */
+  character: number | undefined;
+
+  /**
    * The human-readable diagnostic message describing the issue.
    */
   messageText: string;

--- a/test/src/features/test_compile_line_character.ts
+++ b/test/src/features/test_compile_line_character.ts
@@ -1,0 +1,38 @@
+import { TestValidator } from "@nestia/e2e";
+import { EmbedTypeScript, IEmbedTypeScriptResult } from "embed-typescript";
+import ts from "typescript";
+
+import { TestGlobal } from "../TestGlobal";
+
+export async function test_compile_line_character(): Promise<void> {
+  const compiler: EmbedTypeScript = new EmbedTypeScript({
+    external: await TestGlobal.getExternal(),
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2015,
+      module: ts.ModuleKind.CommonJS,
+      strict: true,
+      skipLibCheck: true,
+    },
+  });
+  // Line 1: const a: number = 1;
+  // Line 2: const b: string = "world";
+  // Line 3: const c: number = "hello";
+  //               ^ TS2322 (line 3, character 7)
+  const source = [
+    "const a: number = 1;",
+    'const b: string = "world";',
+    'const c: number = "hello";',
+  ].join("\n");
+  const result: IEmbedTypeScriptResult = compiler.compile({
+    "src/index.ts": source,
+  });
+  TestValidator.equals("result.type")(result.type)("failure");
+  if (result.type !== "failure") return;
+
+  const diagnostic = result.diagnostics.find(
+    (d) => d.file === "src/index.ts" && d.code === 2322,
+  );
+  TestValidator.predicate("diagnostic exists")(() => diagnostic !== undefined);
+  TestValidator.equals("line")(diagnostic!.line)(3);
+  TestValidator.equals("character")(diagnostic!.character)(7);
+}

--- a/test/src/features/test_eslint_line_character.ts
+++ b/test/src/features/test_eslint_line_character.ts
@@ -1,0 +1,41 @@
+import { TestValidator } from "@nestia/e2e";
+import { EmbedEsLint } from "embed-eslint";
+import { IEmbedTypeScriptResult } from "embed-typescript";
+import ts from "typescript";
+
+import { TestGlobal } from "../TestGlobal";
+
+export const test_eslint_line_character = async (): Promise<void> => {
+  const compiler: EmbedEsLint = new EmbedEsLint({
+    external: await TestGlobal.getExternal(),
+    compilerOptions: {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.CommonJS,
+      strict: true,
+      skipLibCheck: true,
+      esModuleInterop: true,
+    },
+    rules: {
+      "no-floating-promises": "error",
+    },
+  });
+  // Line 1: async function getData(): Promise<number> { return 1; }
+  // Line 2: getData();
+  //          ^ no-floating-promises (line 2, character 1)
+  const source = [
+    "async function getData(): Promise<number> { return 1; }",
+    "getData();",
+  ].join("\n");
+  const result: IEmbedTypeScriptResult = compiler.compile({
+    "src/index.ts": source,
+  });
+  TestValidator.equals("result.type")(result.type)("failure");
+  if (result.type !== "failure") return;
+
+  const diagnostic = result.diagnostics.find(
+    (d) => d.messageText.includes("Promises must be awaited"),
+  );
+  TestValidator.predicate("diagnostic exists")(() => diagnostic !== undefined);
+  TestValidator.equals("line")(diagnostic!.line)(2);
+  TestValidator.equals("character")(diagnostic!.character)(1);
+};


### PR DESCRIPTION
This pull request enhances the diagnostics returned by both the TypeScript and ESLint embedding packages by including precise line and character information for each diagnostic. It also updates the relevant diagnostic interface and adds new tests to verify this functionality.

**Diagnostics Enhancement:**

* The `IEmbedTypeScriptDiagnostic` interface now includes `line` and `character` fields, representing the 1-based line and column where a diagnostic starts.
* The TypeScript embedding logic (`EmbedTypeScript`) has been updated to populate these new fields by extracting line and character information from the TypeScript compiler for each diagnostic. [[1]](diffhunk://#diff-10cd70cb0ba773d4bbad7570ffc49e2043d2a8f159d3bddc45c7826c82d22660L79-R94) [[2]](diffhunk://#diff-10cd70cb0ba773d4bbad7570ffc49e2043d2a8f159d3bddc45c7826c82d22660L152-R175)
* The ESLint embedding logic (`EmbedEsLint.ts`) is updated to set `line` and `character` fields in transformed diagnostics. [[1]](diffhunk://#diff-ecd9246c35de402e3afde71f389c3db5a2df35695807e122e0bbd3e3a87ef641L146-R151) [[2]](diffhunk://#diff-ecd9246c35de402e3afde71f389c3db5a2df35695807e122e0bbd3e3a87ef641R166-R167)

**Testing Improvements:**

* Added `test_compile_line_character.ts` to verify that TypeScript diagnostics include correct line and character information.
* Added `test_eslint_line_character.ts` to verify that ESLint diagnostics include correct line and character information.